### PR TITLE
Add check style to printable checkboxes issue #3

### DIFF
--- a/source/images/check.svg
+++ b/source/images/check.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 8 8" style="enable-background:new 0 0 8 8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#000000;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
+</style>
+<polyline class="st0" points="1.2,4.2 3.1,6.6 6.7,1.4 "/>
+</svg>

--- a/source/stylesheets/style.css.scss
+++ b/source/stylesheets/style.css.scss
@@ -182,17 +182,22 @@ $numbered-section-size: 1.5em;
   }
   @media print {
     input[type='checkbox'] {
-      display: none;
+      -webkit-appearance: none;
+      -moz-appearance: none;
+      -ms-appearance: none;
+      appearance: none;
+      border: 1pt solid #000;
+      background: none;
+      width: 1.2em;
+      height: 1.2em;
+      margin: -.2em .2em .2em -.2em;
+      background-size: contain;
+      &:checked {
+        background-image: url(/images/check.svg);
+      }
     }
     > li {
       margin-left: 3em;
-    }
-    > li:before {
-      content: '☐';
-      font-size: 2em;
-      position: absolute;
-      left: -1em;
-      top: -.4em;
     }
   }
 }


### PR DESCRIPTION
This fixes issue #3 and checkboxes selected in the web version will print when using Chrome or Firefox. Unfortunately I was unable to get Edge to retain the checkbox styling on print.