### PR TITLE
Erasing text on apptmt card

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -67,9 +67,6 @@
   <aside class="card-aside">
     <div class="card-aside-content">
       <p>Please use this appointment card to note the time and day of your upcoming appointment.</p>
-      <small>
-        <p>5 minutes before the appointment time, open your email on the tablet and click on the link to join the appointment. Wait for the provider to join you.</p>
-      </small>
     </div>
     <svg viewBox="0 0 85 80"><use xlink:href="#va-seal"></use></svg>
   </aside>


### PR DESCRIPTION
Erased "5 minutes before" text on apptmt card so that this card works for VMR as well as standard CVT